### PR TITLE
Fix fast api unit from Bytes to Bits

### DIFF
--- a/src/backendFast.mjs
+++ b/src/backendFast.mjs
@@ -23,6 +23,7 @@ export async function speedtestFast() {
         https: true, // default: true
         urlCount: 5, // default: 5
         bufferSize: 8, // default: 8
+        unit: FastSpeedtest.UNITS.bps, // default: FastSpeedtest.UNITS.Bps
     });
 
     return new Promise((resolveFunc) => {

--- a/src/backendFast.mjs
+++ b/src/backendFast.mjs
@@ -7,7 +7,7 @@ async function getFastToken() {
 
     let token = data.match(/token:"(.{32})"/)[1];
 
-    console.log("Recieved API token: ", token);
+    console.log("Received API token: ", token);
 
     return token;
 }


### PR DESCRIPTION
`fast-speedtest-api` has [default unit in `Bytes per second`](https://github.com/branchard/fast-speedtest-api/blob/master/src/Api.js#L43) when your project announce to HA that it uses `(M)bit per second` so I forced the option `unit` to make Fast client return the correct unit. Hope it works as expected since I failed to make the project working locally.